### PR TITLE
Ogawa/#202511 fix

### DIFF
--- a/app/Console/Commands/import_zipcodes.php
+++ b/app/Console/Commands/import_zipcodes.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use App\Models\Zipcodes;
+
+class import_zipcodes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:zipcodes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'import zipcodes';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // 固定パスを指定
+        $filePath = storage_path('app/data/utf_ken_all.csv');
+
+        if (!file_exists($filePath)) {
+            $this->error("CSVファイルが見つかりません: {$filePath}");
+            return 1;
+        }
+
+        if (($handle = fopen($filePath, "r")) !== false) {
+            $rowCount = 0;
+
+            while (($row = fgetcsv($handle)) !== false) {
+                // CSVのカラム調整
+                $zipcode    = trim($row[2]); // 郵便番号（7桁）
+                $prefecture = $row[6]; // 都道府県
+                $city       = $row[7]; // 市区町村
+                $town       = preg_replace('/（.*?）/', '', $row[8]); // 町域
+
+                Zipcodes::updateOrCreate(
+                    ['zipcode' => $zipcode],
+                    [
+                        'prefecture' => $prefecture,
+                        'city'       => $city,
+                        'town'       => $town,
+                    ]
+                );
+
+                $rowCount++;
+            }
+
+            fclose($handle);
+            $this->info("{$rowCount} 件の郵便番号をインポートしました。");
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/Admin/AdminCouponController.php
+++ b/app/Http/Controllers/Admin/AdminCouponController.php
@@ -34,7 +34,7 @@ class AdminCouponController extends Controller
     public function index()
     {
         $user = Auth::guard('admin_user')->user(); //ユーザー情報
-        $coupons = Coupons::select('coupons.*','stores.store_name')->join('stores', 'coupons.store_id', '=', 'stores.id')->orderBy('created_at', 'DESC')->get(); //クーポン情報
+        $coupons = Coupons::select('coupons.*','stores.store_name')->join('stores', 'coupons.store_id', '=', 'stores.id')->orderBy('created_at', 'DESC')->paginate(10); //クーポン情報
         $stores = Stores::select()->get(); //stores情報
         return view('admin.coupon.index', compact('user', 'stores', 'coupons'));
     }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -76,23 +76,26 @@ class SiteController extends Controller
             }
             $user_zipcode = Zipcodes::select()->where('zipcode', $user->postal_code)->first(); //ユーザー市町村情報
             $category = 'area';
-            //ユーザー市町村と一致するものだけ
-            $list_coupons = Coupons::select(
-                    'coupons.*',
-                    'stores.store_name',
-                    'stores.genre',
-                    'stores.station',
-                    'stores.transportation',
-                    'stores.time',
-                    'zipcodes.city'
-                )
-                ->join('stores', 'coupons.store_id', '=', 'stores.id')
-                ->join('zipcodes', 'stores.postal_code', '=', 'zipcodes.zipcode')
-                ->where('expire_start_date', '<=', $date)
-                ->where('expire_end_date', '>=', $date)
-                ->where('zipcodes.city', '=', $user_zipcode->city)
-                ->orderBy('created_at', 'DESC')
-                ->get();
+
+            if ($user_zipcode) {
+                //ユーザー市町村と一致するものだけ
+                $list_coupons = Coupons::select(
+                        'coupons.*',
+                        'stores.store_name',
+                        'stores.genre',
+                        'stores.station',
+                        'stores.transportation',
+                        'stores.time',
+                        'zipcodes.city'
+                    )
+                    ->join('stores', 'coupons.store_id', '=', 'stores.id')
+                    ->join('zipcodes', 'stores.postal_code', '=', 'zipcodes.zipcode')
+                    ->where('expire_start_date', '<=', $date)
+                    ->where('expire_end_date', '>=', $date)
+                    ->where('zipcodes.city', '=', $user_zipcode->city)
+                    ->orderBy('created_at', 'DESC')
+                    ->get();
+            }
         }
 
         foreach ($list_coupons as $coupons) {

--- a/app/Http/Controllers/Store/StoreCouponController.php
+++ b/app/Http/Controllers/Store/StoreCouponController.php
@@ -36,7 +36,7 @@ class StoreCouponController extends Controller
     public function index()
     {
         $user = Auth::guard('store_user')->user(); //ユーザー情報
-        $coupons = Coupons::select('coupons.*','stores.store_name')->join('stores', 'coupons.store_id', '=', 'stores.id')->where('coupons.company_id', $user->company_id)->orderBy('created_at', 'DESC')->get(); //クーポン情報
+        $coupons = Coupons::select('coupons.*','stores.store_name')->join('stores', 'coupons.store_id', '=', 'stores.id')->where('coupons.company_id', $user->company_id)->orderBy('created_at', 'DESC')->paginate(10); //クーポン情報
         $stores = Stores::select()->where('company_id', $user->company_id)->get(); //stores情報
         return view('store.coupon.index', compact('user', 'stores', 'coupons'));
     }
@@ -64,9 +64,9 @@ class StoreCouponController extends Controller
                 'price.required' => 'クーポン定価を入力してください。',
                 'price.numeric' => 'クーポン定価は数値で入力してください。',
                 'price.min' => 'クーポン定価は1円以上にしてください。',
-                'store_pay_price.required' => '店舗支払金額は0円以上にしてください。',
+                'store_pay_price.required' => '店舗支払金額は1円以上にしてください。',
                 'store_pay_price.numeric' => '店舗支払金額は数値で入力してください。',
-                'store_pay_price.min' => '店舗支払金額は0円以上にしてください。',
+                'store_pay_price.min' => '店舗支払金額は1円以上にしてください。',
                 'cource_time.required' => 'コース時間を入力してください。',
                 'cource_start.required' => 'コース開始時間を入力してください。',
                 'detail.required' => '説明を入力してください。',

--- a/app/Http/Controllers/Store/StoreShopController.php
+++ b/app/Http/Controllers/Store/StoreShopController.php
@@ -43,22 +43,39 @@ class StoreShopController extends Controller
     public function create(Request $request)
     {
         $user = Auth::guard('store_user')->user(); //ユーザー情報
-        $request = $request->all();
 
-        if (isset($request['address1'])) {
-            $validated_data = Validator::make($request, [
-                'store_name' => 'required',
-                'email' => 'required|max:190',
-                'postal_code' => 'required',
-                'address1' => 'required',
-                'address2' => 'required',
-                'address3' => 'required',
-                'phone_number' => 'required|max:11',
-                'genre' => 'required',
-                'station_line' => 'required',
-                'station' => 'required',
+        if ($request->isMethod('post')) {
+            //$request = $request->all();
+            $validated_data = Validator::make($request->all(), [
+                'store_name'     => 'required',
+                'email'          => 'required|email|max:190',
+                'postal_code'    => 'required|digits:7',
+                'address1'       => 'required',
+                'address2'       => 'required',
+                'address3'       => 'required',
+                'phone_number'   => 'required|digits_between:10,11',
+                'genre'          => 'required',
+                'station_line'   => 'required',
+                'station'        => 'required',
                 'transportation' => 'required',
-                'time' => 'required',
+                'time'           => 'required',
+            ], [
+                'store_name.required'     => '店舗名を入力してください。',
+                'email.required'          => 'メールアドレスを入力してください。',
+                'email.email'             => '正しいメールアドレス形式で入力してください。',
+                'email.max'               => 'メールアドレスは190文字以内で入力してください。',
+                'postal_code.required'    => '郵便番号を入力してください。',
+                'postal_code.digits'      => '郵便番号は7桁で入力してください。',
+                'address1.required'       => '都道府県を入力してください。',
+                'address2.required'       => '市区町村を入力してください。',
+                'address3.required'       => '住所を入力してください。',
+                'phone_number.required'   => '電話番号を入力してください。',
+                'phone_number.digits_between' => '電話番号は10桁または11桁で入力してください。',
+                'genre.required'          => 'ジャンルを入力してください。',
+                'station_line.required'   => '路線を選択してください。',
+                'station.required'        => '駅を選択してください。',
+                'transportation.required' => '交通手段を選択してください。',
+                'time.required'           => '時間を入力してください。',
             ]);
 
             if ($validated_data->fails()) {
@@ -131,7 +148,6 @@ class StoreShopController extends Controller
     public function edit(Request $request)
     {
         $user = Auth::guard('store_user')->user(); //ユーザー情報
-        $request = $request->all();
 
         if(!isset($request['si'])) {
             abort(404);
@@ -144,20 +160,38 @@ class StoreShopController extends Controller
             abort(404);
         }
 
-        if (isset($request['address1']) && isset($request['p_type']) && $request['p_type'] == 'edit') {
-            $validated_data = Validator::make($request, [
-                'store_name' => 'required',
-                'email' => 'required|max:190',
-                'postal_code' => 'required',
-                'address1' => 'required',
-                'address2' => 'required',
-                'address3' => 'required',
-                'phone_number' => 'required|max:11',
-                'genre' => 'required',
-                'station_line' => 'required',
-                'station' => 'required',
+        if ($request->isMethod('post') && isset($request['p_type']) && $request['p_type'] == 'edit') {
+            //$request = $request->all();
+            $validated_data = Validator::make($request->all(), [
+                'store_name'     => 'required',
+                'email'          => 'required|email|max:190',
+                'postal_code'    => 'required|digits:7',
+                'address1'       => 'required',
+                'address2'       => 'required',
+                'address3'       => 'required',
+                'phone_number'   => 'required|digits_between:10,11',
+                'genre'          => 'required',
+                'station_line'   => 'required',
+                'station'        => 'required',
                 'transportation' => 'required',
-                'time' => 'required',
+                'time'           => 'required',
+            ], [
+                'store_name.required'     => '店舗名を入力してください。',
+                'email.required'          => 'メールアドレスを入力してください。',
+                'email.email'             => '正しいメールアドレス形式で入力してください。',
+                'email.max'               => 'メールアドレスは190文字以内で入力してください。',
+                'postal_code.required'    => '郵便番号を入力してください。',
+                'postal_code.digits'      => '郵便番号は7桁で入力してください。',
+                'address1.required'       => '都道府県を入力してください。',
+                'address2.required'       => '市区町村を入力してください。',
+                'address3.required'       => '住所を入力してください。',
+                'phone_number.required'   => '電話番号を入力してください。',
+                'phone_number.digits_between' => '電話番号は10桁または11桁で入力してください。',
+                'genre.required'          => 'ジャンルを入力してください。',
+                'station_line.required'   => '路線を選択してください。',
+                'station.required'        => '駅を選択してください。',
+                'transportation.required' => '交通手段を選択してください。',
+                'time.required'           => '時間を入力してください。',
             ]);
 
             if ($validated_data->fails()) {
@@ -237,18 +271,25 @@ class StoreShopController extends Controller
     public function accountCreate(Request $request)
     {
         $user = Auth::guard('store_user')->user();  //ユーザー情報
-        $request = $request->all();
 
         if ($_POST) {
-            if (isset($request['name']) || isset($request['password'])) {
-                $validated_data = Validator::make($request, [
-                    'name' => 'required|max:190:',
-                    'password' => 'required',
+            if ($request->isMethod('post')) {
+                $validated_data = Validator::make($request->all(), [
+                    'name' => 'required|min:10|max:100:',
+                    'password' => 'required|min:10|max:100',
+                ], [
+                    'name.required'     => 'ユーザー名を入力してください。',
+                    'name.min'          => 'ユーザー名は10文字以上で入力してください',
+                    'name.max'          => 'ユーザー名は100文字以内で入力してください',
+                    'password.required'             => 'パスワードを入力してください。',
+                    'password.min'               => 'パスワードは10文字以上で入力してください。',
+                    'password.max'               => 'パスワードは100文字以下で入力してください。',
                 ]);
 
                 if ($validated_data->fails()) {
-                    $error = true;
-                    return view('store.shop.account_create', compact('error', 'user'));
+                    return redirect()->route('store.account.create')
+                        ->withErrors($validated_data)
+                        ->withInput();
                 } else {
                     $store_user = StoreUser::create([
                         'name' => $request['name'],
@@ -282,27 +323,36 @@ class StoreShopController extends Controller
         $user = Auth::guard('store_user')->user(); //ユーザー情報
         $stores = Stores::select()->where('company_id', $user->company_id)->get(); //stores情報
 
-        $request = $request->all();
-
         if ($_POST) {
-            if (isset($request['store_name'])) {
-                $validated_data = Validator::make($request, [
-                    'store_name' => 'required',
-                    'cource_name' => 'required|max:190:',
-                    'price' => 'required|regex:/^[1-9][0-9]*/|not_in:0',
-                    'detail' => 'required'
+            if ($request->isMethod('post')) {
+                $validated_data = Validator::make($request->all(), [
+                    'store_name'  => 'required',
+                    'cource_name' => 'required|min:10|max:190',
+                    'price'       => 'required|integer|min:1',
+                    'detail'      => 'required|min:10',
+                ], [
+                    'store_name.required'   => '店舗名を入力してください。',
+                    'cource_name.required'  => 'メニュー名を入力してください。',
+                    'cource_name.min'       => 'メニュー名は10文字以上で入力してください。',
+                    'cource_name.max'       => 'メニュー名は190文字以内で入力してください。',
+                    'price.required'        => '定価を入力してください。',
+                    'price.integer'         => '定価は整数で入力してください。',
+                    'price.min'             => '定価は1以上で入力してください。',
+                    'detail.required'       => '説明を入力してください。',
+                    'detail.min'            => '説明は10文字以上で入力してください。',
                 ]);
 
                 if ($validated_data->fails()) {
-                    $error = true;
-                    return view('store.shop.cource_create', compact('error', 'stores'));
+                    return redirect()->route('store.shop.cource')
+                        ->withErrors($validated_data)
+                        ->withInput();
                 } else {
-                    $store_user = StoreUser::create([
-                        'name' => $request['name'],
-                        'email' => '',
-                        'password' => Hash::make($request['password']),
+                    $store_user = StoreServices::create([
                         'company_id' => (int)$user->company_id,
-                        'parent_user_id' => $user->id,
+                        'store_id' => $request['store_name'],
+                        'service_name' => $request['cource_name'],
+                        'price' => $request['price'],
+                        'detail' => $request['detail'],
                     ]);
 
                     return redirect('/store/cource');
@@ -312,7 +362,7 @@ class StoreShopController extends Controller
             }
         }
 
-        return view('store.shop.cource_create', compact('stores'));
+        return view('store.shop.cource_create', compact('user','stores'));
     }
 
     public function checkStation(Request $request)

--- a/app/Models/StoreServices.php
+++ b/app/Models/StoreServices.php
@@ -11,8 +11,8 @@ class StoreServices extends Authenticatable
 
     protected $table = 'store_services';
 
-    protected $fillable = [
-       
+    protected $guarded = [
+        'id'
     ];
 
     protected $hidden = [

--- a/app/Models/Zipcodes.php
+++ b/app/Models/Zipcodes.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Zipcodes extends Authenticatable
+{
+
+    protected $table = 'zipcodes';
+
+    protected $guarded = [
+       'id'
+    ];
+
+
+    protected $hidden = [
+        
+    ];
+
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/database/migrations/2025_11_27_211439_create_zipcodes_table.php
+++ b/database/migrations/2025_11_27_211439_create_zipcodes_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateZipcodesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('zipcodes', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->nullable();
+            $table->string('zipcode')->nullable();
+            $table->string('prefecture')->nullable();
+            $table->string('city')->nullable();
+            $table->string('town')->nullable();
+            $table->dateTime('created_at');
+            $table->dateTime('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('zipcodes');
+    }
+}

--- a/resources/views/admin/coupon/index.blade.php
+++ b/resources/views/admin/coupon/index.blade.php
@@ -79,5 +79,14 @@
                 </div>
             </div>
         </div>
+        <div class="card-footer d-flex justify-content-between align-items-center">
+            <div>
+                {{ $coupons->links('pagination::bootstrap-4') }}
+            </div>
+            <div class="text-muted">
+                全 {{ $coupons->total() }} 件中 
+                {{ $coupons->firstItem() }} - {{ $coupons->lastItem() }} 件を表示
+            </div>
+        </div>
     </div>
 @endsection

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -695,7 +695,7 @@
     <div class="filter-buttons">
         <button class="active" onclick="location.href='/site/couponlist'">新着</button>
         <button onclick="location.href='/site/couponlist'">お気に入り</button>
-        <button onclick="location.href='/site/couponlist'">マイエリア</button>
+        <button onclick="location.href='/site/couponlist?search=area'">マイエリア</button>
         <button onclick="location.href='/site/couponlist'">お得なクーポン</button>
     </div>
 

--- a/resources/views/layouts/admin/app.blade.php
+++ b/resources/views/layouts/admin/app.blade.php
@@ -23,6 +23,14 @@
 
 @yield('add_head')
 
+<style>
+.custom-logout-btn {
+    background-color: #000000;
+    color: #fff;
+    border: none;
+}
+</style>
+
 </head>
 <body>
     <!-- Page Wrapper -->
@@ -194,12 +202,14 @@
 
                         <!-- Nav Item - Alerts -->
                         <li class="nav-item dropdown no-arrow mx-1">
+                            <?php /*
                             <a class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fas fa-bell fa-fw"></i>
                                 <!-- Counter - Alerts -->
                                 <span class="badge badge-danger badge-counter">3+</span>
                             </a>
+                            */ ?>
                             <!-- Dropdown - Alerts -->
                             <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="alertsDropdown">
@@ -245,12 +255,14 @@
 
                         <!-- Nav Item - Messages -->
                         <li class="nav-item dropdown no-arrow mx-1">
+                            <?php /*
                             <a class="nav-link dropdown-toggle" href="#" id="messagesDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fas fa-envelope fa-fw"></i>
                                 <!-- Counter - Messages -->
                                 <span class="badge badge-danger badge-counter">7</span>
                             </a>
+                            */ ?>
                             <!-- Dropdown - Messages -->
                             <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="messagesDropdown">
@@ -334,6 +346,24 @@
                                         src="img/undraw_profile.svg">
                                 </a>
                                 */ ?>
+                                <li class="nav-item d-flex align-items-center">
+                                    <span class="nav-link d-flex align-items-center">
+                                        <i class="fas fa-user-circle fa-lg mr-2 text-gray-600"></i>
+                                        <span class="font-weight-bold text-gray-800">
+                                            {{ Auth::guard('admin_user')->user()->name }}
+                                        </span>
+                                    </span>
+                                    <a class="btn btn-sm custom-logout-btn ml-2 d-flex align-items-center"
+                                    href="{{ route('admin.logout') }}"
+                                    onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-1"></i>
+                                        ログアウト
+                                    </a>
+                                    <form id="logout-form" action="{{ route('admin.logout') }}" method="POST" class="d-none">
+                                        @csrf
+                                    </form>
+                                </li>
+                                <?php /*
                                 <li class="nav-item dropdown">
                                     <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                         {{ Auth::guard('admin_user')->user()->name }}
@@ -352,6 +382,7 @@
                                             @csrf
                                         </form>
                                     </div>
+                                    */ ?>
                             @endguest
                             <!-- Dropdown - User Information -->
                             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"

--- a/resources/views/layouts/store/app.blade.php
+++ b/resources/views/layouts/store/app.blade.php
@@ -23,6 +23,14 @@
 
 @yield('add_head')
 
+<style>
+.custom-logout-btn {
+    background-color: #996c57;
+    color: #fff;
+    border: none;
+}
+</style>
+
 </head>
 <body>
     <!-- Page Wrapper -->
@@ -237,12 +245,14 @@
 
                         <!-- Nav Item - Alerts -->
                         <li class="nav-item dropdown no-arrow mx-1">
+                            <?php /*
                             <a class="nav-link dropdown-toggle" href="#" id="alertsDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fas fa-bell fa-fw"></i>
                                 <!-- Counter - Alerts -->
                                 <span class="badge badge-danger badge-counter">3+</span>
                             </a>
+                            */ ?>
                             <!-- Dropdown - Alerts -->
                             <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="alertsDropdown">
@@ -288,12 +298,14 @@
 
                         <!-- Nav Item - Messages -->
                         <li class="nav-item dropdown no-arrow mx-1">
+                            <?php /*
                             <a class="nav-link dropdown-toggle" href="#" id="messagesDropdown" role="button"
                                 data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 <i class="fas fa-envelope fa-fw"></i>
                                 <!-- Counter - Messages -->
                                 <span class="badge badge-danger badge-counter">7</span>
                             </a>
+                            */ ?>
                             <!-- Dropdown - Messages -->
                             <div class="dropdown-list dropdown-menu dropdown-menu-right shadow animated--grow-in"
                                 aria-labelledby="messagesDropdown">
@@ -369,32 +381,41 @@
                                     </li>
                                 @endif
                             @else
-                                <?php /*
-                                <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button"
-                                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="mr-2 d-none d-lg-inline text-gray-600 small">Douglas McGee</span>
-                                    <img class="img-profile rounded-circle"
-                                        src="img/undraw_profile.svg">
-                                </a>
-                                */ ?>
+                                <li class="nav-item d-flex align-items-center">
+                                    <span class="nav-link d-flex align-items-center">
+                                        <i class="fas fa-user-circle fa-lg mr-2 text-gray-600"></i>
+                                        <span class="font-weight-bold text-gray-800">
+                                            {{ Auth::guard('store_user')->user()->name }}
+                                        </span>
+                                    </span>
+                                    <a class="btn btn-sm custom-logout-btn ml-2 d-flex align-items-center"
+                                    href="{{ route('store.logout') }}"
+                                    onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-1"></i>
+                                        ログアウト
+                                    </a>
+                                    <form id="logout-form" action="{{ route('store.logout') }}" method="POST" class="d-none">
+                                        @csrf
+                                    </form>
+                                </li>
+                                <?php /*元コード
                                 <li class="nav-item dropdown">
                                     <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                         {{ Auth::guard('store_user')->user()->name }}
                                     </a>
-
-                                    {{--<div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">--}}
                                 </li>
                                 <div>
-                                        <a class="dropdown-item" href="{{ route('store.logout') }}"
-                                        onclick="event.preventDefault();
-                                                        document.getElementById('logout-form').submit();">
-                                            {{ __('Logout') }}
-                                        </a>
+                                    <a class="dropdown-item" href="{{ route('store.logout') }}"
+                                    onclick="event.preventDefault();
+                                                    document.getElementById('logout-form').submit();">
+                                        {{ __('Logout') }}
+                                    </a>
 
-                                        <form id="logout-form" action="{{ route('store.logout') }}" method="POST" class="d-none">
-                                            @csrf
-                                        </form>
-                                    </div>
+                                    <form id="logout-form" action="{{ route('store.logout') }}" method="POST" class="d-none">
+                                        @csrf
+                                    </form>
+                                </div>
+                                */ ?>
                             @endguest
                             <!-- Dropdown - User Information -->
                             <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"

--- a/resources/views/site/coupondetail.blade.php
+++ b/resources/views/site/coupondetail.blade.php
@@ -294,24 +294,20 @@
                 <div class="info">
                     <p><strong>{{ config('commons.genre')[$coupon->genre] }}ー{{ $coupon->store_name }}</strong></p>
                     <p>最寄り駅：{{ $coupon->station }}駅 {{ config('commons.transportation')[$coupon->transportation] }}{{ $coupon->time }}分
-                    @if ($coupon->station_2)
+                    @if ($coupon->station_2 && $coupon->time_2)
                         <br>最寄り駅：{{ $coupon->station_2 }}駅 {{ config('commons.transportation')[$coupon->transportation_2] }}{{ $coupon->time_2 }}分
                     @endif
                     </p>
                     <p>
                         @if ($coupon->discount_rate > 0)
                             <span class="price-before">通常{{ number_format($coupon->price + $coupon->original_service_price) }}円</span>
-                            @if ($coupon->discount_type == 1)
-                                <span class="price-after">→ {{ number_format(round($coupon->price * (1 - ($coupon->discount_price / 100))) + $coupon->service_price) }}円</span>
-                            @else
-                                <span class="price-after">→ {{ number_format(round($coupon->price - $coupon->discount_price) + $coupon->service_price) }}円</span>
-                            @endif
+                            <span class="price-after">→ {{ number_format(round($coupon->store_pay_price) + $coupon->service_price) }}円</span>
                             ({{ $coupon->discount_rate }}%OFF)
                         @else
-                            ¥{{ number_format($coupon->price + $coupon->original_service_price) }}
+                            {{ number_format($coupon->price + $coupon->original_service_price) }}円
                         @endif
                     </p>
-                    <p>予約日時：{{ $coupon->format_cource_start }}</p>
+                    <p>予約日時：{{ $coupon->format_cource_start }}<br>予定所要時間：{{ $coupon->cource_time }}分</p>
                     <p>{{ $coupon->coupon_name }}</p>
                 </div>
             </div>

--- a/resources/views/site/couponlist.blade.php
+++ b/resources/views/site/couponlist.blade.php
@@ -97,55 +97,86 @@
 
     <!-- クーポンリスト -->
     <div class="coupon-list">
-        <a href="/site/coupondetail" class="coupon-item">
-            <div class="coupon-content">
-                <img src="https://picsum.photos/80/80?random=1" alt="店舗画像" class="coupon-thumb" />
-                <div class="coupon-text">
-                    <div class="coupon-title">
-                        <span class="new-badge">NEW!</span>
-                        <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
+        @if (count($list_coupons))
+            @foreach ($list_coupons as $list_coupon)
+                <a href="/site/coupondetail?cid={{ urlencode($list_coupon->coupon_code) }}" class="coupon-item">
+                    <div class="coupon-content">
+                        @if($list_coupon->img_url)
+                            <img src="{{ asset('/assets/images/'. $list_coupon->img_url) }}" alt="クーポン画像" width="80" height="80">
+                        @else
+                            <!--<img src="https://picsum.photos/80/80?random=1" alt="店舗画像" class="coupon-thumb" />-->
+                        @endif
+                        <div class="coupon-text">
+                            <div class="coupon-title">
+                                <span class="new-badge">NEW!</span>
+                                <span class="fading-text">{{ $list_coupon->remaining_minute }}</span>｜{{ $list_coupon->coupon_name }}｜{{ $list_coupon->store_name }}｜{{ $list_coupon->station }} {{ config('commons.transportation')[$list_coupon->transportation] }}{{ $list_coupon->time }}分
+                            </div>
+                            <div class="coupon-price">
+                                @if ($list_coupon->discount_rate > 0)
+                                    <span class="discount-rate">{{ $list_coupon->discount_rate }}%OFF</span>
+                                    <span class="price-before">通常{{ number_format($list_coupon->price + $list_coupon->original_service_price) }}円</span>
+                                    <span class="price-after">→ {{ number_format(round($list_coupon->store_pay_price) + $list_coupon->service_price) }}円</span>
+                                @else
+                                    <span class="price-after">{{ number_format($list_coupon->price + $list_coupon->original_service_price) }}円</span>
+                                @endif
+                            </div>
+                        </div>
                     </div>
-                    <div class="coupon-price">
-                        <span class="discount-rate">50%OFF</span>
-                        <span class="price-before">通常6,000円</span>
-                        <span class="price-after">→ 3,000円</span>
-                    </div>
-                </div>
-            </div>
-        </a>
-        <a href="/site/coupondetail" class="coupon-item">
-            <div class="coupon-content">
-                <img src="https://picsum.photos/80/80?random=2" alt="店舗画像" class="coupon-thumb" />
-                <div class="coupon-text">
-                    <div class="coupon-title">
-                        <span class="new-badge">NEW!</span>
-                        <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
-                    </div>
-                    <div class="coupon-price">
-                        <span class="discount-rate">50%OFF</span>
-                        <span class="price-before">通常6,000円</span>
-                        <span class="price-after">→ 3,000円</span>
-                    </div>
-                </div>
-            </div>
-        </a>
-        <a href="/site/coupondetail" class="coupon-item">
-            <div class="coupon-content">
-                <img src="https://picsum.photos/80/80?random=3" alt="店舗画像" class="coupon-thumb" />
-                <div class="coupon-text">
-                    <div class="coupon-title">
-                        <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
-                    </div>
-                    <div class="coupon-price">
-                        <span class="discount-rate">50%OFF</span>
-                        <span class="price-before">通常6,000円</span>
-                        <span class="price-after">→ 3,000円</span>
+                </a>
+            @endforeach
+            <?php /*元ソース
+            <a href="/site/coupondetail" class="coupon-item">
+                <div class="coupon-content">
+                    <img src="https://picsum.photos/80/80?random=1" alt="店舗画像" class="coupon-thumb" />
+                    <div class="coupon-text">
+                        <div class="coupon-title">
+                            <span class="new-badge">NEW!</span>
+                            <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
+                        </div>
+                        <div class="coupon-price">
+                            <span class="discount-rate">50%OFF</span>
+                            <span class="price-before">通常6,000円</span>
+                            <span class="price-after">→ 3,000円</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </a>
+            </a>
+            <a href="/site/coupondetail" class="coupon-item">
+                <div class="coupon-content">
+                    <img src="https://picsum.photos/80/80?random=2" alt="店舗画像" class="coupon-thumb" />
+                    <div class="coupon-text">
+                        <div class="coupon-title">
+                            <span class="new-badge">NEW!</span>
+                            <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
+                        </div>
+                        <div class="coupon-price">
+                            <span class="discount-rate">50%OFF</span>
+                            <span class="price-before">通常6,000円</span>
+                            <span class="price-after">→ 3,000円</span>
+                        </div>
+                    </div>
+                </div>
+            </a>
+            <a href="/site/coupondetail" class="coupon-item">
+                <div class="coupon-content">
+                    <img src="https://picsum.photos/80/80?random=3" alt="店舗画像" class="coupon-thumb" />
+                    <div class="coupon-text">
+                        <div class="coupon-title">
+                            <span class="fading-text">残り120分</span>｜骨盤矯正（初回限定）｜渋谷整体サロン｜渋谷駅 徒歩3分
+                        </div>
+                        <div class="coupon-price">
+                            <span class="discount-rate">50%OFF</span>
+                            <span class="price-before">通常6,000円</span>
+                            <span class="price-after">→ 3,000円</span>
+                        </div>
+                    </div>
+                </div>
+            </a>
+            */ ?>
+        @else
+            <p>現在、発行中のクーポンはありません</p>
+        @endif
     </div>
-
 </div>
 
 </body>

--- a/resources/views/store/coupon/create.blade.php
+++ b/resources/views/store/coupon/create.blade.php
@@ -17,7 +17,17 @@
         @if (isset($stores) && count($stores) > 0)
 
             @if($errors->any())
-            <div class="d-sm-flex align-items-center justify-content-between mb-4" style="color:red">入力値に誤りがあります。</div>
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <strong>入力値に誤りがあります。</strong>
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                    <button type="button" class="close" data-dismiss="alert" aria-label="">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
             @endif
 
             <form class="user" method="POST" action="{{ route('store.coupon.create') }}" enctype="multipart/form-data">

--- a/resources/views/store/coupon/index.blade.php
+++ b/resources/views/store/coupon/index.blade.php
@@ -90,5 +90,14 @@
                 </div>
             </div>
         </div>
+        <div class="card-footer d-flex justify-content-between align-items-center">
+            <div>
+                {{ $coupons->links('pagination::bootstrap-4') }}
+            </div>
+            <div class="text-muted">
+                全 {{ $coupons->total() }} 件中 
+                {{ $coupons->firstItem() }} - {{ $coupons->lastItem() }} 件を表示
+            </div>
+        </div>
     </div>
 @endsection

--- a/resources/views/store/shop/account_create.blade.php
+++ b/resources/views/store/shop/account_create.blade.php
@@ -14,8 +14,18 @@
             <h1 class="h3 mb-0 text-gray-800">店舗ユーザー登録</h1>
         </div>
 
-        @if(isset($error))
-            <div class="d-sm-flex align-items-center justify-content-between mb-4" style="color:red">ユーザー名、パスワードは必須入力です</div>
+        @if($errors->any())
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong>入力値に誤りがあります。</strong>
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+                <button type="button" class="close" data-dismiss="alert" aria-label="">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
         @endif
 
         <form class="user" method="POST" action="{{ route('store.account.create') }}">
@@ -23,15 +33,25 @@
             <div class="form-group">
                 <label for="name" class="col-md-4 col-form-label text-md-end">ユーザー名</label>
                 <div class="col-sm-10 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="name"
+                    <input type="text" class="form-control @error('name') is-invalid @enderror" name="name"
                         placeholder="">
+                    @error('name')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="name" class="col-md-4 col-form-label text-md-end">パスワード</label>
                 <div class="col-sm-10 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="password"
+                    <input type="text" class="form-control @error('password') is-invalid @enderror" name="password"
                         placeholder="">
+                    @error('password')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group row"style="margin-left:10px">

--- a/resources/views/store/shop/cource_create.blade.php
+++ b/resources/views/store/shop/cource_create.blade.php
@@ -16,8 +16,18 @@
 
         @if (isset($stores) && count($stores) > 0)
 
-            @if(isset($error))
-            <div class="d-sm-flex align-items-center justify-content-between mb-4" style="color:red">入力値に誤りがあります。</div>
+            @if($errors->any())
+                <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                    <strong>入力値に誤りがあります。</strong>
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                    <button type="button" class="close" data-dismiss="alert" aria-label="">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
             @endif
 
             <form class="user" method="POST" action="{{ route('store.shop.cource') }}">
@@ -26,45 +36,50 @@
                     <label for="name" class="col-md-4 col-form-label text-md-end">店舗</label>
                     <div class="col-sm-6 mb-3 mb-sm-0">
                         <select name="store_name" id="name" class="form-control">
-                            <option value="1">店舗1</option>
-                            <option value="2">店舗2</option>
-                            <option value="3">店舗3</option>
+                            @foreach($stores as $store)
+                                <option value="{{$store->id}}">{{$store->store_name}}</option>
+                            @endforeach
                         </select>
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="cource_name" class="col-md-4 col-form-label text-md-end">メニュー名</label>
                     <div class="col-sm-10 mb-3 mb-sm-0">
-                        <input type="text" class="form-control" name="cource_name"
+                        <input type="text" class="form-control @error('cource_name') is-invalid @enderror" name="cource_name"
                             placeholder="">
+                        @error('cource_name')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="price" class="col-md-4 col-form-label text-md-end">クーポン金額</label>
                     <div class="col-sm-3 mb-3 mb-sm-0">
-                        <input type="text" class="form-control" name="price"
+                        <input type="text" class="form-control @error('price') is-invalid @enderror" name="price"
                             placeholder="">
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="discount" class="col-md-4 col-form-label text-md-end">クーポン割引額</label>
-                    <div class="col-sm-3 mb-3 mb-sm-0">
-                        <input type="text" class="form-control" name="discount"
-                            placeholder="">
+                        @error('price')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="detail" class="col-md-4 col-form-label text-md-end">説明</label>
                     <div class="col-sm-10 mb-3 mb-sm-0">
-                        <textarea class="form-control" rows="10" cols="60" name="detail"></textarea>
+                        <textarea class="form-control @error('detail') is-invalid @enderror" rows="10" cols="60" name="detail"></textarea>
+                        @error('detail')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
                 </div>
                 <div class="form-group row"style="margin-left:10px">
                     <div class="col-sm-3 mb-3 mb-sm-0">
                         <input type="submit" class="form-control btn btn-success btn-block" id="">
-                    </div>
-                    <div class="col-sm-3 mb-3 mb-sm-0">
-                        <input type="submit" class="form-control btn btn-primary btn-block" id="">
                     </div>
                 </div>
             </form>

--- a/resources/views/store/shop/create.blade.php
+++ b/resources/views/store/shop/create.blade.php
@@ -15,7 +15,17 @@
         </div>
 
         @if($errors->any())
-            <div class="d-sm-flex align-items-center justify-content-between mb-4" style="color:red">入力値に誤りがあります。</div>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong>入力値に誤りがあります。</strong>
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+                <button type="button" class="close" data-dismiss="alert" aria-label="">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
         @endif
 
         <form class="user" method="POST" action="{{ route('store.shop.create') }}" enctype="multipart/form-data">
@@ -23,28 +33,43 @@
             <div class="form-group">
                 <label for="store_name" class="col-md-4 col-form-label text-md-end">店舗名<span class="text-danger">*</span></label>
                 <div class="col-sm-10 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="store_name"
+                    <input type="text" class="form-control @error('store_name') is-invalid @enderror" name="store_name"
                            value="{{ old('store_name') }}" placeholder="">
+                    @error('store_name')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="email" class="col-md-4 col-form-label text-md-end">メールアドレス<span class="text-danger">*</span></label>
                 <div class="col-sm-6 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="email"
+                    <input type="text" class="form-control @error('email') is-invalid @enderror" name="email"
                            value="{{ old('email') }}" placeholder="">
+                    @error('store_name')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
-                <label for="postal_code" class="col-md-4 col-form-label text-md-end">郵便番号<span class="text-danger">*</span></label>
+                <label for="postal_code" class="col-md-4 col-form-label text-md-end">郵便番号(ハイフンなし)<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="postal_code"
+                    <input type="text" class="form-control @error('postal_code') is-invalid @enderror" name="postal_code"
                            value="{{ old('postal_code') }}" placeholder="">
+                    @error('postal_code')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="address1" class="col-md-4 col-form-label text-md-end">都道府県<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <select name="address1" id="address1" class="form-control">
+                    <select name="address1" id="address1 @error('address1') is-invalid @enderror" class="form-control">
                         <option value="">選択してください</option>
                         @foreach(config('commons.prefectures') as $key => $prefecture)
                             <option value="{{ $key }}"
@@ -53,27 +78,47 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('address1')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="address2" class="col-md-4 col-form-label text-md-end">市区町村<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="address2"
+                    <input type="text" class="form-control @error('address2') is-invalid @enderror" name="address2"
                            value="{{ old('address2') }}" placeholder="">
+                    @error('address2')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="address3" class="col-md-4 col-form-label text-md-end">住所<span class="text-danger">*</span></label>
                 <div class="col-sm-10 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="address3"
+                    <input type="text" class="form-control @error('address3') is-invalid @enderror" name="address3"
                            value="{{ old('address3') }}" placeholder="">
+                    @error('address3')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="phone_number" class="col-md-4 col-form-label text-md-end">電話番号<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <input type="text" class="form-control" name="phone_number"
+                    <input type="text" class="form-control @error('phone_number') is-invalid @enderror" name="phone_number"
                            value="{{ old('phone_number') }}" placeholder="">
+                    @error('phone_number')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -86,7 +131,7 @@
             <div class="form-group">
                 <label for="genre" class="col-md-4 col-form-label text-md-end">ジャンル<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <select name="genre" id="genre" class="form-control">
+                    <select name="genre" id="genre" class="form-control @error('genre') is-invalid @enderror">
                         @foreach(config('commons.genre') as $gkey => $genre)
                             <option value="{{ $gkey }}"
                                 {{ old('genre', $defaultGenre ?? '') == $gkey ? 'selected' : '' }}>
@@ -94,28 +139,43 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('genre')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="station_line" class="col-md-4 col-form-label text-md-end">最寄り駅<span class="text-danger">*</span></label>
                 <div class="row"style="margin-left:0px">
                     <div class="col-sm-3 mb-3 mb-sm-0">路線
-                        <select name="station_line" id="station_line" class="form-control">
+                        <select name="station_line" id="station_line" class="form-control @error('station_line') is-invalid @enderror">
                             <option selected disabled>都道府県を選択してください</option>
                         </select>
+                        @error('station_line')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
 
                     <div class="col-sm-3 mb-3 mb-sm-0">駅
-                        <select name="station" id="station" class="form-control">
+                        <select name="station" id="station" class="form-control @error('station') is-invalid @enderror">
                             <option selected disabled>路線を選択してください</option>
                         </select>
+                        @error('station')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
                 </div>
             </div>
             <div class="form-group">
                 <label for="transportation" class="col-md-4 col-form-label text-md-end">交通手段<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <select name="transportation" id="transportation" class="form-control">
+                    <select name="transportation" id="transportation" class="form-control @error('transportation') is-invalid @enderror">
                         @foreach(config('commons.transportation') as $tkey => $transportation)
                             <option value="{{ $tkey }}"
                                 {{ old('transportation', $defaultTransportation ?? '') == $tkey ? 'selected' : '' }}>
@@ -123,12 +183,22 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('transportation')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="time" class="col-md-4 col-form-label text-md-end">時間(分)<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <input type="number" class="form-control" name="time" id="time" min="1" value="{{ old('time') }}" placeholder="">
+                    <input type="number" class="form-control @error('time') is-invalid @enderror" name="time" id="time" min="1" value="{{ old('time') }}" placeholder="">
+                    @error('time')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">

--- a/resources/views/store/shop/edit.blade.php
+++ b/resources/views/store/shop/edit.blade.php
@@ -15,7 +15,17 @@
         </div>
 
         @if($errors->any())
-            <div class="d-sm-flex align-items-center justify-content-between mb-4" style="color:red">入力値に誤りがあります。</div>
+            <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                <strong>入力値に誤りがあります。</strong>
+                <ul class="mb-0">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+                <button type="button" class="close" data-dismiss="alert" aria-label="">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
         @endif
 
         <form class="user" method="POST" action="{{ route('store.shop.edit') }}" enctype="multipart/form-data">
@@ -25,6 +35,11 @@
                 <div class="col-sm-10 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="store_name"
                            value="{{ old('store_name', $store_data->store_name) }}" placeholder="">
+                    @error('store_name')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -32,13 +47,23 @@
                 <div class="col-sm-6 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="email"
                            value="{{ old('email', $store_data->email) }}" placeholder="">
+                    @error('store_name')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
-                <label for="postal_code" class="col-md-4 col-form-label text-md-end">郵便番号<span class="text-danger">*</span></label>
+                <label for="postal_code" class="col-md-4 col-form-label text-md-end">郵便番号(ハイフンなし)<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="postal_code"
                            value="{{ old('postal_code', $store_data->postal_code) }}" placeholder="">
+                    @error('postal_code')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -51,6 +76,11 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('address1')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -58,6 +88,11 @@
                 <div class="col-sm-3 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="address2"
                            value="{{ old('address2', $store_data->address2) }}" placeholder="">
+                    @error('address2')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -65,6 +100,11 @@
                 <div class="col-sm-10 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="address3"
                            value="{{ old('address3', $store_data->address3) }}" placeholder="">
+                    @error('address3')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -72,6 +112,11 @@
                 <div class="col-sm-3 mb-3 mb-sm-0">
                     <input type="text" class="form-control" name="phone_number"
                            value="{{ old('phone_number', $store_data->phone_number) }}" placeholder="">
+                    @error('phone_number')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -91,6 +136,11 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('genre')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -100,12 +150,22 @@
                         <select name="station_line" id="station_line" class="form-control">
                             <option selected disabled>都道府県を選択してください</option>
                         </select>
+                        @error('station_line')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
 
                     <div class="col-sm-3 mb-3 mb-sm-0">駅
                         <select name="station" id="station" class="form-control">
                             <option selected disabled>路線を選択してください</option>
                         </select>
+                        @error('station')
+                            <span class="invalid-feedback" role="alert">
+                                <strong>{{ $message }}</strong>
+                            </span>
+                        @enderror
                     </div>
                 </div>
             </div>
@@ -120,12 +180,22 @@
                             </option>
                         @endforeach
                     </select>
+                    @error('transportation')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
                 <label for="time" class="col-md-4 col-form-label text-md-end">時間(分)<span class="text-danger">*</span></label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
                     <input type="number" class="form-control" name="time" id="time" min="1" value="{{ old('time', $store_data->time ?? '') }}" placeholder="">
+                    @error('time')
+                        <span class="invalid-feedback" role="alert">
+                            <strong>{{ $message }}</strong>
+                        </span>
+                    @enderror
                 </div>
             </div>
             <div class="form-group">
@@ -160,7 +230,7 @@
             <div class="form-group">
                 <label for="time_2" class="col-md-4 col-form-label text-md-end">時間(分) 2</label>
                 <div class="col-sm-3 mb-3 mb-sm-0">
-                    <input type="number" class="form-control" name="time_2" id="time_2" min="1" value="{{ old('time_2', $store_data->time_2 ?? '') }}" placeholder="">
+                    <input type="number" class="form-control" name="time_2" id="time_2" min="1" value="{{ old('time_2', $store_data->time_2 ?: '') }}" placeholder="">
                 </div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
・郵便番号テーブル追加、CSV読み込みバッジ
(https://www.post.japanpost.jp/zipcode/dl/utf-zip.html から都度CSVダウンロードして指定場所へ置く)
【郵便番号更新手順】
①https://www.post.japanpost.jp/zipcode/dl/utf-zip.html　から最新データをダウンロード
②ダウンロードした「utf_ken_all.csv」を /storage/app/data ディレクトリに置く
③php aritsan import:zipcodes コマンドを実行

・郵便番号からの市町村一致でマイエリアクーポンの表示
・admin、store管理画面のブラッシュアップ
→ページャーテスト追加
→バリデーションの表示
→ヘッダーの調整